### PR TITLE
## 1.1.3+2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.3+2
+
+- Remove `_` while route constant was start with `/`, which will cause
+  the constant unreachable.
+
 ## 1.1.3+1
 
 - Remove the deprecated `author:` field from pubspec.yaml

--- a/lib/src/route_generator.dart
+++ b/lib/src/route_generator.dart
@@ -202,13 +202,16 @@ class RouteGenerator {
 
             final _firstLine = _description ?? _routeName ?? _name;
 
-            final _constant = _name
+            var _constant = _name
                 .replaceAll('\"', '')
                 .replaceAll('://', '_')
                 .replaceAll('/', '_')
                 .replaceAll('.', '_')
                 .replaceAll(' ', '_')
                 .replaceAll('-', '_');
+            while (_constant.startsWith('_')) {
+              _constant = _constant.replaceFirst('_', '');
+            }
 
             sb.write('/// $_firstLine\n');
             sb.write('///');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ff_annotation_route
 description: Provide a route generator to create route map quickly by annotations.
-version: 1.1.3+1
+version: 1.1.3+2
 homepage: https://github.com/fluttercandies/ff_annotation_route
 
 environment:


### PR DESCRIPTION
Remove `_` while route constant was start with `/`, which will cause the constant unreachable.