### PR TITLE
Apply trailing comma to args for `require_trailing_commas` lint rule

### DIFF
--- a/lib/src/route_info.dart
+++ b/lib/src/route_info.dart
@@ -319,13 +319,13 @@ class RouteInfo {
       final StringBuffer sb = StringBuffer();
       for (final ConstructorDeclaration rawConstructor in constructors!) {
         final String? name = rawConstructor.name?.toString();
-        if (name == null && rawConstructor.parameters.parameters.isEmpty) {
+        final FormalParameterList parameters = rawConstructor.parameters;
+        if (name == null && parameters.parameters.isEmpty) {
           continue;
         }
-        String args = rawConstructor.parameters.toString();
+        String args = parameters.toString();
         String nameMap = '';
-        for (final FormalParameter parameter
-            in rawConstructor.parameters.parameters) {
+        for (final FormalParameter parameter in parameters.parameters) {
           final String parameterS = parameter.toString();
           final String name = parameter.identifier!.name;
           if (parameterS.contains('this.')) {
@@ -349,6 +349,15 @@ class RouteInfo {
         }
         if (name != null) {
           nameMap += ''''$constructorName':'$name',''';
+        }
+        if (args.isNotEmpty && parameters.parameters.isNotEmpty) {
+          if (args.endsWith('})')) {
+            args = args.replaceAll('})', ',})');
+          } else if (args.endsWith('])')) {
+            args = args.replaceAll('])', ',])');
+          } else {
+            args = args.replaceAll(')', ',)');
+          }
         }
 
         sb.write(routeConstClassMethodTemplate


### PR DESCRIPTION
This will apply trailing commas to super arguments, according to the [`require_trailing_commas`](https://dart-lang.github.io/linter/lints/require_trailing_commas.html) lint rules.

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/15884415/134849933-1b7584d3-a192-421d-b211-45ed74fac56b.png) | ![image](https://user-images.githubusercontent.com/15884415/134849968-9d527328-9e1d-4f2f-b37d-268477e24c13.png) |